### PR TITLE
Use h3.speed.cloudflare.com instead of AIM

### DIFF
--- a/cli/src/args/mod.rs
+++ b/cli/src/args/mod.rs
@@ -47,7 +47,7 @@ pub enum Command {
     Rtt {
         /// The URL to perform a GET request against. The full GET time is not
         /// measured, just the TCP handshake.
-        #[clap(default_value = "https://aim.cloudflare.com/responsiveness/api/v1/small")]
+        #[clap(default_value = "https://h3.speed.cloudflare.com/__down?bytes=10")]
         #[clap(short, long)]
         url: String,
         /// How many measurements to perform.

--- a/cli/src/args/packet_loss.rs
+++ b/cli/src/args/packet_loss.rs
@@ -37,14 +37,14 @@ pub struct PacketLossArgs {
     #[clap(
         short = 'd',
         long = "download",
-        default_value = "https://aim.cloudflare.com/responsiveness/api/v1/large"
+        default_value = "https://h3.speed.cloudflare.com/__down?bytes=10000000000"
     )]
     pub download_url: String,
     /// The upload url which accepts an arbitrary amount of data.
     #[clap(
         short = 'u',
         long = "upload",
-        default_value = "https://aim.cloudflare.com/responsiveness/api/v1/upload"
+        default_value = "https://h3.speed.cloudflare.com/__up"
     )]
     pub upload_url: String,
 }

--- a/cli/src/args/rpm.rs
+++ b/cli/src/args/rpm.rs
@@ -25,21 +25,21 @@ pub struct RpmArgs {
     #[clap(
         short = 'l',
         long = "large",
-        default_value = "https://aim.cloudflare.com/responsiveness/api/v1/large"
+        default_value = "https://h3.speed.cloudflare.com/__down?bytes=10000000000"
     )]
     pub large_download_url: String,
     /// The small file endpoint which should be very small, only a few bytes.
     #[clap(
         short = 's',
         long = "small",
-        default_value = "https://aim.cloudflare.com/cdn-cgi/build/nginx-ssl"
+        default_value = "https://h3.speed.cloudflare.com/__down?bytes=10"
     )]
     pub small_download_url: String,
     /// The upload url which accepts an arbitrary amount of data.
     #[clap(
         short = 'u',
         long = "upload",
-        default_value = "https://aim.cloudflare.com/responsiveness/api/v1/upload"
+        default_value = "https://h3.speed.cloudflare.com/__up"
     )]
     pub upload_url: String,
     /// The number of intervals to use when calculating the moving average.
@@ -75,10 +75,10 @@ impl Default for RpmArgs {
     fn default() -> Self {
         Self {
             config: None,
-            large_download_url: "https://aim.cloudflare.com/responsiveness/api/v1/large"
+            large_download_url: "https://h3.speed.cloudflare.com/__down?bytes=10000000000"
                 .to_string(),
-            small_download_url: "https://aim.cloudflare.com/cdn-cgi/build/nginx-ssl".to_string(),
-            upload_url: "https://aim.cloudflare.com/responsiveness/api/v1/upload".to_string(),
+            small_download_url: "https://h3.speed.cloudflare.com/__down?bytes=10".to_string(),
+            upload_url: "https://h3.speed.cloudflare.com/__up".to_string(),
             moving_average_distance: 4,
             std_tolerance: 0.05,
             trimmed_mean_percent: 0.95,

--- a/cli/src/args/up_down.rs
+++ b/cli/src/args/up_down.rs
@@ -12,7 +12,7 @@ use crate::args::ConnType;
 #[derive(Debug, Args)]
 pub struct DownloadArgs {
     /// The URL to download data from.
-    #[clap(default_value = "https://aim.cloudflare.com/responsiveness/api/v1/small")]
+    #[clap(default_value = "https://h3.speed.cloudflare.com/__down?bytes=10")]
     pub(crate) url: String,
     #[clap(default_value = "h2")]
     pub(crate) conn_type: ConnType,
@@ -25,7 +25,7 @@ pub struct DownloadArgs {
 #[derive(Debug, Args)]
 pub struct UploadArgs {
     /// The URL to upload data to.
-    #[clap(default_value = "https://aim.cloudflare.com/responsiveness/api/v1/upload")]
+    #[clap(default_value = "https://h3.speed.cloudflare.com/__up")]
     pub(crate) url: String,
     /// The type of the connection.
     #[clap(default_value = "h2")]

--- a/crates/nq-latency/src/lib.rs
+++ b/crates/nq-latency/src/lib.rs
@@ -22,7 +22,7 @@ pub struct LatencyConfig {
 impl Default for LatencyConfig {
     fn default() -> Self {
         Self {
-            url: "https://aim.cloudflare.com/responsiveness/api/v1/small"
+            url: "https://h3.speed.cloudflare.com/__down?bytes=10"
                 .parse()
                 .unwrap(),
             runs: 20,

--- a/crates/nq-packetloss/src/lib.rs
+++ b/crates/nq-packetloss/src/lib.rs
@@ -52,10 +52,10 @@ impl Default for PacketLossConfig {
             batch_size: 10,
             batch_wait_time: Duration::from_millis(10),
             response_wait_time: Duration::from_millis(3000),
-            download_url: "https://aim.cloudflare.com/responsiveness/api/v1/large"
+            download_url: "https://h3.speed.cloudflare.com/__down?bytes=10000000000"
                 .parse()
                 .unwrap(),
-            upload_url: "https://aim.cloudflare.com/responsiveness/api/v1/upload"
+            upload_url: "https://h3.speed.cloudflare.com/__up"
                 .parse()
                 .unwrap(),
         }
@@ -350,10 +350,10 @@ mod tests {
             batch_size,
             batch_wait_time: Duration::from_millis(batch_wait_time),
             response_wait_time: Duration::from_millis(response_wait_time),
-            download_url: "https://aim.cloudflare.com/responsiveness/api/v1/large"
+            download_url: "https://h3.speed.cloudflare.com/__down?bytes=10000000000"
                 .parse()
                 .unwrap(),
-            upload_url: "https://aim.cloudflare.com/responsiveness/api/v1/upload"
+            upload_url: "https://h3.speed.cloudflare.com/__up"
                 .parse()
                 .unwrap(),
         };
@@ -458,10 +458,10 @@ mod tests {
             batch_size: 10,
             batch_wait_time: Duration::from_millis(25),
             response_wait_time: Duration::from_millis(100),
-            download_url: "https://aim.cloudflare.com/responsiveness/api/v1/large"
+            download_url: "https://h3.speed.cloudflare.com/__down?bytes=10000000000"
                 .parse()
                 .unwrap(),
-            upload_url: "https://aim.cloudflare.com/responsiveness/api/v1/upload"
+            upload_url: "https://h3.speed.cloudflare.com/__up"
                 .parse()
                 .unwrap(),
         };

--- a/crates/nq-rpm/src/lib.rs
+++ b/crates/nq-rpm/src/lib.rs
@@ -49,13 +49,13 @@ impl ResponsivenessConfig {
 impl Default for ResponsivenessConfig {
     fn default() -> Self {
         Self {
-            large_download_url: "https://aim.cloudflare.com/responsiveness/api/v1/large"
+            large_download_url: "https://h3.speed.cloudflare.com/__down?bytes=10000000000"
                 .parse()
                 .unwrap(),
-            small_download_url: "https://aim.cloudflare.com/cdn-cgi/build/nginx-ssl"
+            small_download_url: "https://h3.speed.cloudflare.com/__down?bytes=10"
                 .parse()
                 .unwrap(),
-            upload_url: "https://aim.cloudflare.com/responsiveness/api/v1/upload"
+            upload_url: "https://h3.speed.cloudflare.com/__up"
                 .parse()
                 .unwrap(),
             moving_average_distance: 4,


### PR DESCRIPTION
The `aim.cloudflare.com/responsiveness/*` endpoints are deprecated and will be removed in the future. Use the endpoints from `speed.cloudflare.com` instead.