### PR TITLE
Fix visibility on PacketLossResult

### DIFF
--- a/cli/src/args/packet_loss.rs
+++ b/cli/src/args/packet_loss.rs
@@ -8,12 +8,10 @@ use clap::Args;
 /// Send UDP packets to a TURN server, reporting lost packets.
 #[derive(Debug, Args)]
 pub struct PacketLossArgs {
-    /// The target TURN server URI to send UDP packets
-    #[clap(default_value = "turn:turn.speed.cloudflare.com:50000?transport=udp")]
+    /// The target TURN server URI to send UDP packets. User's will have to provide a TURN server.
     #[clap(short = 't', long)]
     pub turn_uri: String,
     /// The URL to send the request to for TURN server credentials
-    #[clap(default_value = "https://speed.cloudflare.com/turn-creds")]
     #[clap(short = 'c', long)]
     pub turn_cred_url: String,
     /// Total number of messages/packets to send
@@ -33,14 +31,14 @@ pub struct PacketLossArgs {
     #[clap(short = 'r', long)]
     pub response_wait_time_ms: u64,
 
-    /// The large file endpoint which should be multiple GBs.
+    /// The download file endpoint used for load generation which should be multiple GBs.
     #[clap(
         short = 'd',
         long = "download",
         default_value = "https://h3.speed.cloudflare.com/__down?bytes=10000000000"
     )]
     pub download_url: String,
-    /// The upload url which accepts an arbitrary amount of data.
+    /// The upload url used for load generation which accepts an arbitrary amount of data.
     #[clap(
         short = 'u',
         long = "upload",

--- a/crates/nq-packetloss/src/lib.rs
+++ b/crates/nq-packetloss/src/lib.rs
@@ -16,7 +16,7 @@ use nq_core::{
 use nq_load_generator::{LoadConfig, LoadGenerator, LoadedConnection};
 use nq_tokio_network::TokioNetwork;
 use serde::{Deserialize, Serialize};
-use std::{cmp::min, collections::HashMap, sync::Arc, time::Duration};
+use std::{cmp::min, collections::HashMap, fmt::Display, sync::Arc, time::Duration};
 use tokio::sync::{mpsc, RwLock};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
@@ -308,9 +308,19 @@ impl PacketLoss {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct PacketLossResult {
     /// Number of messages received during test
-    num_messages: usize,
+    pub num_messages: usize,
     /// Calculated ratio based on expected returned messages and actual
-    loss_ratio: f64,
+    pub loss_ratio: f64,
+}
+
+impl Display for PacketLossResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "messages: {} loss ratio: {:.2}",
+            self.num_messages, self.loss_ratio,
+        )
+    }
 }
 
 pub enum PacketLossEvent {


### PR DESCRIPTION
- Make PacketLossResult members public and add a Display function
- Remove default TURN servers as they are being deprecated