### PR TITLE
Allow rpm test to run in non-tls mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,6 +1179,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,3 +28,4 @@ tokio = { workspace = true, features = ["rt-multi-thread", "time", "net", "macro
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+url = { workspace = true }

--- a/cli/src/args/rpm.rs
+++ b/cli/src/args/rpm.rs
@@ -69,6 +69,10 @@ pub struct RpmArgs {
     /// https://blog.cloudflare.com/aim-database-for-internet-quality/
     #[clap(long)]
     pub disable_aim_scores: bool,
+    /// Disable TLS for H1 connections (plain TCP). When set, HTTP/1.1 is used
+    /// without a TLS handshake; otherwise HTTP/2 is preferred.
+    #[clap(long = "no-tls")]
+    pub no_tls: bool,
 }
 
 impl Default for RpmArgs {
@@ -86,6 +90,7 @@ impl Default for RpmArgs {
             interval_duration_ms: 1000, // 1s
             test_duration_ms: 12_000,   // 12s
             disable_aim_scores: false,
+            no_tls: false,
         }
     }
 }

--- a/cli/src/latency.rs
+++ b/cli/src/latency.rs
@@ -22,6 +22,7 @@ pub async fn run(url: String, runs: usize) -> anyhow::Result<()> {
     let result = run_test(&LatencyConfig {
         url: url.parse()?,
         runs,
+        no_tls: false,
     })
     .await?;
 
@@ -48,6 +49,7 @@ pub async fn run_test(config: &LatencyConfig) -> anyhow::Result<LatencyResult> {
     let network = Arc::new(TokioNetwork::new(
         Arc::clone(&time),
         shutdown.clone(),
+        config.no_tls,
     )) as Arc<dyn Network>;
 
     let rtt = Latency::new(config.clone());

--- a/cli/src/packet_loss.rs
+++ b/cli/src/packet_loss.rs
@@ -49,6 +49,7 @@ async fn fetch_turn_server_creds(
     let network = Arc::new(TokioNetwork::new(
         Arc::clone(&time) as Arc<dyn Time>,
         shutdown.clone(),
+        false,
     ));
 
     let host = config

--- a/cli/src/rpm.rs
+++ b/cli/src/rpm.rs
@@ -25,10 +25,11 @@ use crate::util::pretty_secs_to_ms;
 pub async fn run(cli_config: RpmArgs) -> anyhow::Result<()> {
     info!("running responsiveness test");
 
-    let rpm_urls = match cli_config.config.clone() {
+
+    let mut rpm_urls = match cli_config.config.clone() {
         Some(endpoint) => {
             info!("fetching configuration from {endpoint}");
-            let urls = get_rpm_config(endpoint).await?.urls;
+            let urls = get_rpm_config(endpoint, cli_config.no_tls).await?.urls;
             info!("retrieved configuration urls: {urls:?}");
 
             urls
@@ -45,11 +46,41 @@ pub async fn run(cli_config: RpmArgs) -> anyhow::Result<()> {
         }
     };
 
+    // If --no-tls is specified, automatically convert provided HTTPS test URLs to HTTP.
+    // We only rewrite schemes; host, path, query, fragment remain unchanged.
+    if cli_config.no_tls {
+        let downgrade = |orig: &str| -> String {
+            if let Ok(mut url) = url::Url::parse(orig) {
+                if url.scheme() == "https" {
+                    // Ignore result of set_scheme (fails only if new scheme invalid length per spec).
+                    let _ = url.set_scheme("http");
+                    return url.to_string();
+                }
+            }
+            orig.to_string()
+        };
+
+        let original = rpm_urls.clone();
+        rpm_urls.small_https_download_url = downgrade(&rpm_urls.small_https_download_url);
+        rpm_urls.large_https_download_url = downgrade(&rpm_urls.large_https_download_url);
+        rpm_urls.https_upload_url = downgrade(&rpm_urls.https_upload_url);
+        info!(
+            "converted urls for --no-tls: small: {} -> {}, large: {} -> {}, upload: {} -> {}",
+            original.small_https_download_url,
+            rpm_urls.small_https_download_url,
+            original.large_https_download_url,
+            rpm_urls.large_https_download_url,
+            original.https_upload_url,
+            rpm_urls.https_upload_url
+        );
+    }
+
     // first get unloaded RTT measurements
     info!("determining unloaded latency");
     let rtt_result = crate::latency::run_test(&LatencyConfig {
         url: rpm_urls.small_https_download_url.parse()?,
         runs: 20,
+        no_tls: cli_config.no_tls,
     })
     .await?;
     info!(
@@ -74,6 +105,7 @@ pub async fn run(cli_config: RpmArgs) -> anyhow::Result<()> {
         trimmed_mean_percent: cli_config.trimmed_mean_percent,
         std_tolerance: cli_config.std_tolerance,
         max_loaded_connections: cli_config.max_loaded_connections,
+        no_tls: cli_config.no_tls,
     };
 
     info!("running download test");
@@ -120,6 +152,7 @@ async fn run_test(
     let network = Arc::new(TokioNetwork::new(
         Arc::clone(&time),
         shutdown.clone().into(),
+        config.no_tls,
     )) as Arc<dyn Network>;
 
     let rpm = Responsiveness::new(config.clone(), download)?;
@@ -139,7 +172,7 @@ pub struct RpmServerConfig {
     urls: RpmUrls,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RpmUrls {
     #[serde(alias = "small_download_url")]
     small_https_download_url: String,
@@ -149,16 +182,19 @@ pub struct RpmUrls {
     https_upload_url: String,
 }
 
-pub async fn get_rpm_config(config_url: String) -> anyhow::Result<RpmServerConfig> {
+pub async fn get_rpm_config(config_url: String, no_tls: bool) -> anyhow::Result<RpmServerConfig> {
     let shutdown = CancellationToken::new();
     let time = Arc::new(TokioTime::new());
     let network = Arc::new(TokioNetwork::new(
         Arc::clone(&time) as Arc<dyn Time>,
         shutdown.clone(),
+        no_tls,
     ));
 
+    let conn_type = if no_tls { ConnectionType::H1 } else { ConnectionType::H2 };
     let response = Client::default()
-        .new_connection(ConnectionType::H2)
+        .plain_http_mode(no_tls)
+        .new_connection(conn_type)
         .method("GET")
         .send(
             config_url.parse().context("parsing rpm config url")?,

--- a/cli/src/up_down.rs
+++ b/cli/src/up_down.rs
@@ -20,8 +20,7 @@ use serde_json::json;
 pub async fn download(args: DownloadArgs) -> anyhow::Result<()> {
     let shutdown = CancellationToken::new();
     let time = Arc::new(TokioTime::new()) as Arc<dyn Time>;
-    let network =
-        Arc::new(TokioNetwork::new(Arc::clone(&time), shutdown.clone())) as Arc<dyn Network>;
+    let network = Arc::new(TokioNetwork::new(Arc::clone(&time), shutdown.clone(), false)) as Arc<dyn Network>;
 
     let conn_type = match args.conn_type {
         ConnType::H1 => ConnectionType::H1,
@@ -87,8 +86,7 @@ pub async fn download(args: DownloadArgs) -> anyhow::Result<()> {
 pub async fn upload(args: UploadArgs) -> anyhow::Result<()> {
     let shutdown = CancellationToken::new();
     let time = Arc::new(TokioTime::new()) as Arc<dyn Time>;
-    let network =
-        Arc::new(TokioNetwork::new(Arc::clone(&time), shutdown.clone())) as Arc<dyn Network>;
+    let network = Arc::new(TokioNetwork::new(Arc::clone(&time), shutdown.clone(), false)) as Arc<dyn Network>;
 
     let conn_type = match args.conn_type {
         ConnType::H1 => ConnectionType::H1, // ConnectionType::H1,

--- a/crates/nq-core/src/lib.rs
+++ b/crates/nq-core/src/lib.rs
@@ -26,5 +26,6 @@ pub use crate::{
     util::{oneshot_result, OneshotResult, ResponseFuture},
 };
 
+
 pub use anyhow::Error;
 pub use anyhow::Result;

--- a/crates/nq-packetloss/src/lib.rs
+++ b/crates/nq-packetloss/src/lib.rs
@@ -69,6 +69,7 @@ impl PacketLossConfig {
             download_url: self.download_url.clone(),
             upload_url: self.upload_url.clone(),
             upload_size: 4_000_000_000, // 4 GB
+            no_tls: false,
         }
     }
 }
@@ -104,7 +105,7 @@ impl PacketLoss {
         // Start generating load on the network in both directions
         let time = Arc::new(TokioTime::new()) as Arc<dyn Time>;
         let network =
-            Arc::new(TokioNetwork::new(Arc::clone(&time), shutdown.clone())) as Arc<dyn Network>;
+            Arc::new(TokioNetwork::new(Arc::clone(&time), shutdown.clone(), false)) as Arc<dyn Network>;
 
         self.new_load_generating_connection(
             packet_event_tx.clone(),

--- a/crates/nq-tokio-network/src/lib.rs
+++ b/crates/nq-tokio-network/src/lib.rs
@@ -23,10 +23,8 @@ pub struct TokioNetwork {
 }
 
 impl TokioNetwork {
-    pub fn new(time: Arc<dyn Time>, shutdown: CancellationToken) -> Self {
-        Self {
-            inner: TokioNetworkInner::new(time, shutdown),
-        }
+    pub fn new(time: Arc<dyn Time>, shutdown: CancellationToken, no_tls: bool) -> Self {
+        Self { inner: TokioNetworkInner::new(time, shutdown, no_tls) }
     }
 }
 
@@ -123,8 +121,8 @@ pub struct TokioNetworkInner {
 }
 
 impl TokioNetworkInner {
-    pub fn new(time: Arc<dyn Time>, shutdown: CancellationToken) -> Self {
-        let connections: Arc<ConnectionManager> = Default::default();
+    pub fn new(time: Arc<dyn Time>, shutdown: CancellationToken, no_tls: bool) -> Self {
+        let connections: Arc<ConnectionManager> = Arc::new(ConnectionManager::new(no_tls));
 
         tokio::spawn({
             let connections = Arc::clone(&connections);
@@ -137,11 +135,7 @@ impl TokioNetworkInner {
             }
         });
 
-        Self {
-            connections,
-            time,
-            shutdown,
-        }
+        Self { connections, time, shutdown }
     }
 
     async fn new_connection(


### PR DESCRIPTION
Added a flag `--no-tls` to the mach rpm entrypoint and forced download/upload/latency requests to not go over TLS.

The reason for this change: We are seeing high cpu usage for mach's rpm test. We compared it to the ookla speedtest cli tool and mach was using significantly more cpu.

I instrumented mach and saw that a lot of the usage is in crypto operations. I also did some pcaps on the ookla tool and saw that they were doing bare HTTP traffic. This seems appropriate since the data that is being transferred isn't sensitive.


![tls-flamegraph (8)](https://github.com/user-attachments/assets/aedda1a6-2a36-489b-83e2-67dcca516188)


After the changes, you can see all of the crypto calls are now gone and we can see better results. The AIM reporting still will use HTTPS.

![http-flamegraph](https://github.com/user-attachments/assets/1c230717-6cad-417f-b946-a5513571b442)


A couple of observations from making this change:
1. Just moving to http/port 80 was not enough. h2 was having issue with the http endpoint so had to force h1
2. h1 expects more headers in general and some other tweaks to work e2e with the default urls
3. the aim report seems to only be https which makes sense considering it is actually transporting interesting data that we would want to secure
4. uploads (POST) seemed to not like the really large uploads when doing just http. Had to limit the size of the uplaods to 16Mb. It seemed that the upload connection was being broken early in this case when too large. Probably endpoints didn't like someone uploading huge files over http.
5. The loaded latency measurements in http mode were having issues getting decent numbers. I believe it was because the connection was being overwhelmed and there is no multiplexing in http 1.1, so made a scheme where it would use finished connections