### PR TITLE
Fix upload timeout error and add configurable timeout

### DIFF
--- a/cli/src/rpm.rs
+++ b/cli/src/rpm.rs
@@ -106,7 +106,11 @@ pub async fn run(cli_config: RpmArgs) -> anyhow::Result<()> {
 
     println!("{}", serde_json::to_string_pretty(&report)?);
 
-    let _ = timeout(Duration::from_secs(1), upload_handle).await;
+    let upload_timeout_secs = std::env::var("MACH_UPLOAD_TIMEOUT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(5);
+    let _ = timeout(Duration::from_secs(upload_timeout_secs), upload_handle).await;
 
     Ok(())
 }


### PR DESCRIPTION
Fixes the 'channel closed' error by increasing the default upload timeout from 1s to 5s and adds support for configuring the timeout via the MACH_UPLOAD_TIMEOUT environment variable. I am not tied to 5s default though.