### PR TITLE
feat: scoped cf-access-token header for internal endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,36 +108,6 @@ information on what's happening internally, run mach with `RUST_LOG=info` set.
 RUST_LOG=info mach
 ```
 
-## Testing Cloudflare internal/staging endpoints
-
-> This feature is intended for Cloudflare-internal use. It allows `mach` to test
-> speed test endpoints that are gated behind Cloudflare Access, such as the
-> staging responsiveness servers.
-
-Set the `MACH_CF_ACCESS_TOKEN` environment variable to a valid Cloudflare Access
-service token. When set, `mach` attaches a `cf-access-token` header to its test
-requests so the Access-gated host lets them through:
-
-```shell
-MACH_CF_ACCESS_TOKEN="<token>" \
-  mach rpm -c https://staging.speed.cloudflare.com/responsiveness/api/v1/config
-```
-
-The token is only ever sent to hosts under `speed.cloudflare.com` (matched on
-strict domain-label boundaries). It is never attached to an unrelated origin,
-even if a remote configuration returns URLs pointing elsewhere. This scoping
-applies across the `rpm`, `download`, `upload`, `saturate`, `rtt`, and
-`packet-loss` subcommands.
-
-Notes:
-
-- An unset or blank `MACH_CF_ACCESS_TOKEN` is ignored (no header is sent). An
-  invalid token value fails fast at startup.
-- Headers passed explicitly with `-H` take precedence and are never overwritten
-  by the scoped token.
-- The token value is marked sensitive and is redacted (printed as `Sensitive`)
-  in `mach`'s request/response debug logs.
-
 # Architecture
 
 The main complexity in the repo is due to the `Network` and `Time` trait

--- a/README.md
+++ b/README.md
@@ -108,6 +108,36 @@ information on what's happening internally, run mach with `RUST_LOG=info` set.
 RUST_LOG=info mach
 ```
 
+## Testing Cloudflare internal/staging endpoints
+
+> This feature is intended for Cloudflare-internal use. It allows `mach` to test
+> speed test endpoints that are gated behind Cloudflare Access, such as the
+> staging responsiveness servers.
+
+Set the `MACH_CF_ACCESS_TOKEN` environment variable to a valid Cloudflare Access
+service token. When set, `mach` attaches a `cf-access-token` header to its test
+requests so the Access-gated host lets them through:
+
+```shell
+MACH_CF_ACCESS_TOKEN="<token>" \
+  mach rpm -c https://staging.speed.cloudflare.com/responsiveness/api/v1/config
+```
+
+The token is only ever sent to hosts under `speed.cloudflare.com` (matched on
+strict domain-label boundaries). It is never attached to an unrelated origin,
+even if a remote configuration returns URLs pointing elsewhere. This scoping
+applies across the `rpm`, `download`, `upload`, `saturate`, `rtt`, and
+`packet-loss` subcommands.
+
+Notes:
+
+- An unset or blank `MACH_CF_ACCESS_TOKEN` is ignored (no header is sent). An
+  invalid token value fails fast at startup.
+- Headers passed explicitly with `-H` take precedence and are never overwritten
+  by the scoped token.
+- The token value is marked sensitive and is redacted (printed as `Sensitive`)
+  in `mach`'s request/response debug logs.
+
 # Architecture
 
 The main complexity in the repo is due to the `Network` and `Time` trait

--- a/cli/src/access.rs
+++ b/cli/src/access.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2023-2024 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+//! Cloudflare Access support for testing internal/staging endpoints.
+//!
+//! When the `MACH_CF_ACCESS_TOKEN` environment variable is set, mach attaches a
+//! `cf-access-token` header to its test requests so that Cloudflare
+//! Access-gated hosts (such as the staging speed test endpoints) can be
+//! reached. The token is only ever attached to hosts on the allowlist below so
+//! that it is never leaked to an unrelated origin returned by a remote
+//! configuration.
+
+use anyhow::Context;
+use http::{HeaderMap, HeaderValue};
+use nq_core::ScopedHeaders;
+
+/// Environment variable holding the Cloudflare Access token.
+const ACCESS_TOKEN_ENV: &str = "MACH_CF_ACCESS_TOKEN";
+
+/// Header used to carry the Cloudflare Access token.
+const ACCESS_TOKEN_HEADER: &str = "cf-access-token";
+
+/// Domain suffixes the access token may be sent to. Matching is done with
+/// strict label boundaries by [`ScopedHeaders`].
+const ALLOWED_HOST_SUFFIXES: &[&str] = &["speed.cloudflare.com"];
+
+/// Build the scoped headers carrying the Cloudflare Access token, if the
+/// `MACH_CF_ACCESS_TOKEN` environment variable is set to a non-empty value.
+///
+/// Returns `Ok(None)` when the variable is unset or blank. Returns an error
+/// when the token is not a valid header value, so a misconfigured token fails
+/// fast at startup rather than silently sending no header.
+pub fn cf_access_scoped_headers() -> anyhow::Result<Option<ScopedHeaders>> {
+    let Ok(token) = std::env::var(ACCESS_TOKEN_ENV) else {
+        return Ok(None);
+    };
+
+    let token = token.trim();
+    if token.is_empty() {
+        return Ok(None);
+    }
+
+    let mut value = HeaderValue::from_str(token)
+        .with_context(|| format!("{ACCESS_TOKEN_ENV} is not a valid header value"))?;
+    // Mark the value sensitive so it is redacted (printed as `Sensitive`) in
+    // request/response debug logs.
+    value.set_sensitive(true);
+
+    let mut headers = HeaderMap::new();
+    headers.insert(ACCESS_TOKEN_HEADER, value);
+
+    let allowed_host_suffixes = ALLOWED_HOST_SUFFIXES
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    Ok(Some(ScopedHeaders::new(headers, allowed_host_suffixes)))
+}

--- a/cli/src/access.rs
+++ b/cli/src/access.rs
@@ -1,21 +1,20 @@
 // Copyright (c) 2023-2024 Cloudflare, Inc.
 // Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
 
-//! Cloudflare Access support for testing internal/staging endpoints.
+//! Cloudflare Access support for testing gated endpoints.
 //!
-//! When the `MACH_CF_ACCESS_TOKEN` environment variable is set, mach attaches a
+//! When the `_MACH_CF_ACCESS_TOKEN` environment variable is set, mach attaches a
 //! `cf-access-token` header to its test requests so that Cloudflare
-//! Access-gated hosts (such as the staging speed test endpoints) can be
-//! reached. The token is only ever attached to hosts on the allowlist below so
-//! that it is never leaked to an unrelated origin returned by a remote
-//! configuration.
+//! Access-gated hosts can be reached. The token is only ever attached to hosts
+//! on the allowlist below so that it is never leaked to an unrelated origin
+//! returned by a remote configuration.
 
 use anyhow::Context;
 use http::{HeaderMap, HeaderValue};
 use nq_core::ScopedHeaders;
 
 /// Environment variable holding the Cloudflare Access token.
-const ACCESS_TOKEN_ENV: &str = "MACH_CF_ACCESS_TOKEN";
+const ACCESS_TOKEN_ENV: &str = "_MACH_CF_ACCESS_TOKEN";
 
 /// Header used to carry the Cloudflare Access token.
 const ACCESS_TOKEN_HEADER: &str = "cf-access-token";
@@ -25,7 +24,7 @@ const ACCESS_TOKEN_HEADER: &str = "cf-access-token";
 const ALLOWED_HOST_SUFFIXES: &[&str] = &["speed.cloudflare.com"];
 
 /// Build the scoped headers carrying the Cloudflare Access token, if the
-/// `MACH_CF_ACCESS_TOKEN` environment variable is set to a non-empty value.
+/// `_MACH_CF_ACCESS_TOKEN` environment variable is set to a non-empty value.
 ///
 /// Returns `Ok(None)` when the variable is unset or blank. Returns an error
 /// when the token is not a valid header value, so a misconfigured token fails

--- a/cli/src/latency.rs
+++ b/cli/src/latency.rs
@@ -22,6 +22,7 @@ pub async fn run(url: String, runs: usize) -> anyhow::Result<()> {
     let result = run_test(&LatencyConfig {
         url: url.parse()?,
         runs,
+        scoped_headers: crate::access::cf_access_scoped_headers()?,
     })
     .await?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-2024 Cloudflare, Inc.
 // Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
 
+mod access;
 mod aim_report;
 pub(crate) mod args;
 mod latency;

--- a/cli/src/packet_loss.rs
+++ b/cli/src/packet_loss.rs
@@ -59,13 +59,11 @@ async fn fetch_turn_server_creds(
     let mut headers = HeaderMap::new();
     headers.append(hyper::header::HOST, HeaderValue::from_str(host)?);
 
-    let mut client = Client::default()
+    let client = Client::default()
         .new_connection(ConnectionType::h1())
         .method("GET")
-        .headers(headers);
-    if let Some(scoped_headers) = config.scoped_headers.clone() {
-        client = client.scoped_headers(scoped_headers);
-    }
+        .headers(headers)
+        .scoped_headers(config.scoped_headers.clone());
 
     let response = client
         .send(

--- a/cli/src/packet_loss.rs
+++ b/cli/src/packet_loss.rs
@@ -26,6 +26,7 @@ pub async fn run(args: PacketLossArgs) -> anyhow::Result<()> {
         response_wait_time: Duration::from_millis(args.response_wait_time_ms),
         download_url: args.download_url.parse()?,
         upload_url: args.upload_url.parse()?,
+        scoped_headers: crate::access::cf_access_scoped_headers()?,
     };
 
     info!("fetching TURN server credentials");
@@ -58,10 +59,15 @@ async fn fetch_turn_server_creds(
     let mut headers = HeaderMap::new();
     headers.append(hyper::header::HOST, HeaderValue::from_str(host)?);
 
-    let response = Client::default()
+    let mut client = Client::default()
         .new_connection(ConnectionType::h1())
         .method("GET")
-        .headers(headers)
+        .headers(headers);
+    if let Some(scoped_headers) = config.scoped_headers.clone() {
+        client = client.scoped_headers(scoped_headers);
+    }
+
+    let response = client
         .send(
             request_url.to_string().parse()?,
             http_body_util::Empty::new(),

--- a/cli/src/rpm.rs
+++ b/cli/src/rpm.rs
@@ -25,10 +25,12 @@ use crate::util::pretty_secs_to_ms;
 pub async fn run(cli_config: RpmArgs) -> anyhow::Result<()> {
     info!("running responsiveness test");
 
+    let scoped_headers = crate::access::cf_access_scoped_headers()?;
+
     let rpm_urls = match cli_config.config.clone() {
         Some(endpoint) => {
             info!("fetching configuration from {endpoint}");
-            let urls = get_rpm_config(endpoint).await?.urls;
+            let urls = get_rpm_config(endpoint, scoped_headers.clone()).await?.urls;
             info!("retrieved configuration urls: {urls:?}");
 
             urls
@@ -53,6 +55,7 @@ pub async fn run(cli_config: RpmArgs) -> anyhow::Result<()> {
     let rtt_result = crate::latency::run_test(&LatencyConfig {
         url: rpm_urls.small_https_download_url.parse()?,
         runs: 20,
+        scoped_headers: scoped_headers.clone(),
     })
     .await?;
     info!(
@@ -79,6 +82,7 @@ pub async fn run(cli_config: RpmArgs) -> anyhow::Result<()> {
         max_loaded_connections: cli_config.max_loaded_connections,
         conn_type: ConnectionType::H2,
         determine_load_only: false,
+        scoped_headers,
     };
 
     info!("running download test");
@@ -156,7 +160,10 @@ pub struct RpmUrls {
     https_upload_url: String,
 }
 
-pub async fn get_rpm_config(config_url: String) -> anyhow::Result<RpmServerConfig> {
+pub async fn get_rpm_config(
+    config_url: String,
+    scoped_headers: Option<nq_core::ScopedHeaders>,
+) -> anyhow::Result<RpmServerConfig> {
     let shutdown = CancellationToken::new();
     let time = Arc::new(TokioTime::new());
     let network = Arc::new(TokioNetwork::new(
@@ -164,9 +171,14 @@ pub async fn get_rpm_config(config_url: String) -> anyhow::Result<RpmServerConfi
         shutdown.clone(),
     ));
 
-    let response = Client::default()
+    let mut client = Client::default()
         .new_connection(ConnectionType::H2)
-        .method("GET")
+        .method("GET");
+    if let Some(scoped_headers) = scoped_headers {
+        client = client.scoped_headers(scoped_headers);
+    }
+
+    let response = client
         .send(
             config_url.parse().context("parsing rpm config url")?,
             http_body_util::Empty::new(),

--- a/cli/src/rpm.rs
+++ b/cli/src/rpm.rs
@@ -171,12 +171,10 @@ pub async fn get_rpm_config(
         shutdown.clone(),
     ));
 
-    let mut client = Client::default()
+    let client = Client::default()
         .new_connection(ConnectionType::H2)
-        .method("GET");
-    if let Some(scoped_headers) = scoped_headers {
-        client = client.scoped_headers(scoped_headers);
-    }
+        .method("GET")
+        .scoped_headers(scoped_headers);
 
     let response = client
         .send(

--- a/cli/src/saturate.rs
+++ b/cli/src/saturate.rs
@@ -30,6 +30,7 @@ pub async fn run(cli_config: SaturateArgs) -> anyhow::Result<()> {
         determine_load_only: true,
         conn_type: cli_config.conn_type.into(),
         test_duration: Duration::from_secs(cli_config.duration),
+        scoped_headers: crate::access::cf_access_scoped_headers()?,
         ..Default::default()
     };
 

--- a/cli/src/up_down.rs
+++ b/cli/src/up_down.rs
@@ -26,10 +26,9 @@ pub async fn download(args: DownloadArgs) -> anyhow::Result<()> {
     let conn_type = args.conn_type.into();
     info!("downloading: {}", args.url);
 
-    let mut client = ThroughputClient::download().new_connection(conn_type);
-    if let Some(scoped_headers) = crate::access::cf_access_scoped_headers()? {
-        client = client.scoped_headers(scoped_headers);
-    }
+    let client = ThroughputClient::download()
+        .new_connection(conn_type)
+        .scoped_headers(crate::access::cf_access_scoped_headers()?);
 
     let inflight_body = client
         .send(
@@ -111,12 +110,10 @@ pub async fn upload(args: UploadArgs) -> anyhow::Result<()> {
         info!("added header: {key}");
     }
 
-    let mut client = ThroughputClient::upload(bytes)
+    let client = ThroughputClient::upload(bytes)
         .new_connection(conn_type)
-        .headers(headers);
-    if let Some(scoped_headers) = crate::access::cf_access_scoped_headers()? {
-        client = client.scoped_headers(scoped_headers);
-    }
+        .headers(headers)
+        .scoped_headers(crate::access::cf_access_scoped_headers()?);
 
     let inflight_body = client
         .send(

--- a/cli/src/up_down.rs
+++ b/cli/src/up_down.rs
@@ -26,8 +26,12 @@ pub async fn download(args: DownloadArgs) -> anyhow::Result<()> {
     let conn_type = args.conn_type.into();
     info!("downloading: {}", args.url);
 
-    let inflight_body = ThroughputClient::download()
-        .new_connection(conn_type)
+    let mut client = ThroughputClient::download().new_connection(conn_type);
+    if let Some(scoped_headers) = crate::access::cf_access_scoped_headers()? {
+        client = client.scoped_headers(scoped_headers);
+    }
+
+    let inflight_body = client
         .send(
             args.url.parse().context("parsing download url")?,
             Arc::clone(&network),
@@ -107,9 +111,14 @@ pub async fn upload(args: UploadArgs) -> anyhow::Result<()> {
         info!("added header: {key}");
     }
 
-    let inflight_body = ThroughputClient::upload(bytes)
+    let mut client = ThroughputClient::upload(bytes)
         .new_connection(conn_type)
-        .headers(headers)
+        .headers(headers);
+    if let Some(scoped_headers) = crate::access::cf_access_scoped_headers()? {
+        client = client.scoped_headers(scoped_headers);
+    }
+
+    let inflight_body = client
         .send(
             args.url.parse()?,
             Arc::clone(&network),

--- a/crates/nq-core/src/client.rs
+++ b/crates/nq-core/src/client.rs
@@ -96,8 +96,8 @@ impl ThroughputClient {
 
     /// Set headers that are only attached when the request's host matches the
     /// scope's allowlist. Headers set via [`Self::headers`] take precedence.
-    pub fn scoped_headers(mut self, scoped_headers: ScopedHeaders) -> Self {
-        self.scoped_headers = Some(scoped_headers);
+    pub fn scoped_headers(mut self, scoped_headers: Option<ScopedHeaders>) -> Self {
+        self.scoped_headers = scoped_headers;
         self
     }
 
@@ -394,8 +394,8 @@ impl Client {
 
     /// Set headers that are only attached when the request's host matches the
     /// scope's allowlist. Headers set via [`Self::headers`] take precedence.
-    pub fn scoped_headers(mut self, scoped_headers: ScopedHeaders) -> Self {
-        self.scoped_headers = Some(scoped_headers);
+    pub fn scoped_headers(mut self, scoped_headers: Option<ScopedHeaders>) -> Self {
+        self.scoped_headers = scoped_headers;
         self
     }
 

--- a/crates/nq-core/src/client.rs
+++ b/crates/nq-core/src/client.rs
@@ -19,7 +19,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, error, info, trace};
 
 use crate::{
-    ConnectionType, EstablishedConnection, Network, OneshotResult, Time, Timestamp,
+    ConnectionType, EstablishedConnection, Network, OneshotResult, ScopedHeaders, Time, Timestamp,
     body::{BodyEvent, CountingBody, InflightBody, NqBody, UploadBody, empty},
     oneshot_result,
 };
@@ -49,6 +49,7 @@ pub struct ThroughputClient {
     connection: Option<Arc<RwLock<EstablishedConnection>>>,
     new_connection_type: Option<ConnectionType>,
     headers: Option<HeaderMap>,
+    scoped_headers: Option<ScopedHeaders>,
     direction: Direction,
 }
 
@@ -59,6 +60,7 @@ impl ThroughputClient {
             connection: None,
             new_connection_type: None,
             headers: None,
+            scoped_headers: None,
             direction: Direction::Down,
         }
     }
@@ -69,6 +71,7 @@ impl ThroughputClient {
             connection: None,
             new_connection_type: None,
             headers: None,
+            scoped_headers: None,
             direction: Direction::Up(size),
         }
     }
@@ -88,6 +91,13 @@ impl ThroughputClient {
     /// Set the headers for the upload or download request.
     pub fn headers(mut self, headers: HeaderMap<HeaderValue>) -> Self {
         self.headers = Some(headers);
+        self
+    }
+
+    /// Set headers that are only attached when the request's host matches the
+    /// scope's allowlist. Headers set via [`Self::headers`] take precedence.
+    pub fn scoped_headers(mut self, scoped_headers: ScopedHeaders) -> Self {
+        self.scoped_headers = Some(scoped_headers);
         self
     }
 
@@ -147,6 +157,10 @@ impl ThroughputClient {
                 empty().boxed()
             }
         };
+
+        if let Some(scoped_headers) = self.scoped_headers.take() {
+            scoped_headers.apply(&uri, &mut headers);
+        }
 
         let mut request = http::Request::builder()
             .method(method)
@@ -355,6 +369,7 @@ pub struct Client {
     connection: Option<Arc<RwLock<EstablishedConnection>>>,
     new_connection_type: Option<ConnectionType>,
     headers: Option<HeaderMap>,
+    scoped_headers: Option<ScopedHeaders>,
     method: Option<String>,
 }
 
@@ -374,6 +389,13 @@ impl Client {
     /// Set the headers for the upload or download request.
     pub fn headers(mut self, headers: HeaderMap<HeaderValue>) -> Self {
         self.headers = Some(headers);
+        self
+    }
+
+    /// Set headers that are only attached when the request's host matches the
+    /// scope's allowlist. Headers set via [`Self::headers`] take precedence.
+    pub fn scoped_headers(mut self, scoped_headers: ScopedHeaders) -> Self {
+        self.scoped_headers = Some(scoped_headers);
         self
     }
 
@@ -410,6 +432,10 @@ impl Client {
             .context("could not resolve large download url")?;
 
         let method: http::Method = self.method.as_deref().unwrap_or("GET").parse()?;
+
+        if let Some(scoped_headers) = self.scoped_headers {
+            scoped_headers.apply(&uri, &mut headers);
+        }
 
         let mut request = http::Request::builder()
             .method(method)

--- a/crates/nq-core/src/lib.rs
+++ b/crates/nq-core/src/lib.rs
@@ -13,6 +13,7 @@ mod body;
 pub mod client;
 mod connection;
 mod network;
+mod scoped_headers;
 mod time;
 mod upgraded;
 mod util;
@@ -21,6 +22,7 @@ pub use crate::{
     body::{BodyEvent, CountingBody, NqBody},
     connection::{ConnectionManager, ConnectionTiming, ConnectionType, EstablishedConnection},
     network::Network,
+    scoped_headers::ScopedHeaders,
     time::{Time, Timestamp, TokioTime},
     upgraded::ConnectUpgraded,
     util::{OneshotResult, ResponseFuture, oneshot_result},

--- a/crates/nq-core/src/scoped_headers.rs
+++ b/crates/nq-core/src/scoped_headers.rs
@@ -1,0 +1,66 @@
+// Copyright (c) 2023-2024 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+//! Headers that are only attached to requests whose host matches an allowlist.
+//!
+//! This is a generic mechanism: callers supply the headers and the list of
+//! allowed domain suffixes. It is used to attach sensitive headers (such as an
+//! access token) to trusted hosts only, so the header is never sent to an
+//! unrelated origin returned by a remote configuration.
+
+use http::{HeaderMap, Uri};
+
+/// A set of headers attached to a request only when the request's host matches
+/// one of the allowed domain suffixes.
+///
+/// Matching uses strict label boundaries: a host matches a suffix when it is
+/// equal to the suffix or ends with `.` followed by the suffix. This prevents
+/// look-alike hosts such as `example.com.evil.com` from matching `example.com`.
+///
+/// Existing headers are never overwritten, so a header set explicitly by the
+/// caller takes precedence over a scoped header with the same name.
+#[derive(Debug, Clone, Default)]
+pub struct ScopedHeaders {
+    headers: HeaderMap,
+    allowed_host_suffixes: Vec<String>,
+}
+
+impl ScopedHeaders {
+    /// Create a new [`ScopedHeaders`] from the headers to attach and the list
+    /// of allowed domain suffixes.
+    pub fn new(headers: HeaderMap, allowed_host_suffixes: Vec<String>) -> Self {
+        Self {
+            headers,
+            allowed_host_suffixes,
+        }
+    }
+
+    /// Returns whether the given host is covered by an allowed suffix, using
+    /// strict label-boundary matching.
+    pub fn allows_host(&self, host: &str) -> bool {
+        self.allowed_host_suffixes.iter().any(|suffix| {
+            host == suffix
+                || (host.len() > suffix.len()
+                    && host.ends_with(suffix)
+                    && host.as_bytes()[host.len() - suffix.len() - 1] == b'.')
+        })
+    }
+
+    /// Attach the scoped headers to `headers` when the URI's host matches an
+    /// allowed suffix. Headers already present in `headers` are left untouched.
+    pub fn apply(&self, uri: &Uri, headers: &mut HeaderMap) {
+        let Some(host) = uri.host() else {
+            return;
+        };
+
+        if !self.allows_host(host) {
+            return;
+        }
+
+        for (name, value) in self.headers.iter() {
+            if !headers.contains_key(name) {
+                headers.append(name, value.clone());
+            }
+        }
+    }
+}

--- a/crates/nq-core/src/scoped_headers.rs
+++ b/crates/nq-core/src/scoped_headers.rs
@@ -28,7 +28,16 @@ pub struct ScopedHeaders {
 impl ScopedHeaders {
     /// Create a new [`ScopedHeaders`] from the headers to attach and the list
     /// of allowed domain suffixes.
+    ///
+    /// Suffixes are normalized (lowercased and stripped of any trailing dot) so
+    /// matching in [`allows_host`](Self::allows_host) is case-insensitive and
+    /// tolerant of fully-qualified (trailing-dot) hostnames.
     pub fn new(headers: HeaderMap, allowed_host_suffixes: Vec<String>) -> Self {
+        let allowed_host_suffixes = allowed_host_suffixes
+            .into_iter()
+            .map(|s| s.trim_end_matches('.').to_ascii_lowercase())
+            .collect();
+
         Self {
             headers,
             allowed_host_suffixes,
@@ -37,9 +46,13 @@ impl ScopedHeaders {
 
     /// Returns whether the given host is covered by an allowed suffix, using
     /// strict label-boundary matching.
+    ///
+    /// Matching is case-insensitive (DNS hostnames are case-insensitive) and
+    /// ignores a trailing dot on the host (fully-qualified domain names).
     pub fn allows_host(&self, host: &str) -> bool {
+        let host = host.trim_end_matches('.').to_ascii_lowercase();
         self.allowed_host_suffixes.iter().any(|suffix| {
-            host == suffix
+            host == *suffix
                 || (host.len() > suffix.len()
                     && host.ends_with(suffix)
                     && host.as_bytes()[host.len() - suffix.len() - 1] == b'.')

--- a/crates/nq-core/src/scoped_headers.rs
+++ b/crates/nq-core/src/scoped_headers.rs
@@ -77,3 +77,154 @@ impl ScopedHeaders {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::{HeaderName, HeaderValue};
+
+    const TEST_HEADER: &str = "x-test-token";
+    const SUFFIX: &str = "speed.cloudflare.com";
+
+    /// Build a [`ScopedHeaders`] carrying a single `x-test-token` header scoped
+    /// to the given suffixes.
+    fn scoped(suffixes: &[&str]) -> ScopedHeaders {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static(TEST_HEADER),
+            HeaderValue::from_static("secret"),
+        );
+        ScopedHeaders::new(
+            headers,
+            suffixes.iter().map(|s| s.to_string()).collect(),
+        )
+    }
+
+    // --- allows_host: matching ---
+
+    #[test]
+    fn allows_exact_match() {
+        assert!(scoped(&[SUFFIX]).allows_host("speed.cloudflare.com"));
+    }
+
+    #[test]
+    fn allows_subdomain_match() {
+        assert!(scoped(&[SUFFIX]).allows_host("staging.speed.cloudflare.com"));
+    }
+
+    #[test]
+    fn allows_deep_subdomain_match() {
+        assert!(scoped(&[SUFFIX]).allows_host("a.b.speed.cloudflare.com"));
+    }
+
+    #[test]
+    fn allows_any_of_multiple_suffixes() {
+        let scoped = scoped(&["example.com", SUFFIX]);
+        assert!(scoped.allows_host("speed.cloudflare.com"));
+        assert!(scoped.allows_host("www.example.com"));
+    }
+
+    // --- allows_host: case insensitivity & trailing dot ---
+
+    #[test]
+    fn allows_case_insensitive_host() {
+        assert!(scoped(&[SUFFIX]).allows_host("SPEED.Cloudflare.COM"));
+    }
+
+    #[test]
+    fn allows_trailing_dot_fqdn() {
+        assert!(scoped(&[SUFFIX]).allows_host("speed.cloudflare.com."));
+    }
+
+    #[test]
+    fn allows_trailing_dot_subdomain() {
+        assert!(scoped(&[SUFFIX]).allows_host("staging.speed.cloudflare.com."));
+    }
+
+    #[test]
+    fn allows_suffix_normalized_case_and_trailing_dot() {
+        // Suffix supplied with mixed case and a trailing dot must still match a
+        // lowercase host, verifying normalization in `new`.
+        assert!(scoped(&["SPEED.Cloudflare.com."]).allows_host("speed.cloudflare.com"));
+    }
+
+    // --- allows_host: rejection (security boundary) ---
+
+    #[test]
+    fn rejects_look_alike_prefix() {
+        assert!(!scoped(&[SUFFIX]).allows_host("notspeed.cloudflare.com"));
+    }
+
+    #[test]
+    fn rejects_look_alike_suffix() {
+        assert!(!scoped(&[SUFFIX]).allows_host("speed.cloudflare.com.evil.com"));
+    }
+
+    #[test]
+    fn rejects_empty_host() {
+        assert!(!scoped(&[SUFFIX]).allows_host(""));
+    }
+
+    #[test]
+    fn rejects_unrelated_host() {
+        assert!(!scoped(&[SUFFIX]).allows_host("example.com"));
+    }
+
+    #[test]
+    fn rejects_host_shorter_than_suffix() {
+        assert!(!scoped(&[SUFFIX]).allows_host("cloudflare.com"));
+    }
+
+    #[test]
+    fn rejects_partial_trailing_label() {
+        // Host ends with the suffix bytes but not on a label boundary.
+        assert!(!scoped(&[SUFFIX]).allows_host("xspeed.cloudflare.com"));
+    }
+
+    // --- apply ---
+
+    #[test]
+    fn apply_attaches_header_to_matching_host() {
+        let uri: Uri = "https://staging.speed.cloudflare.com/config"
+            .parse()
+            .unwrap();
+        let mut headers = HeaderMap::new();
+        scoped(&[SUFFIX]).apply(&uri, &mut headers);
+        assert_eq!(
+            headers.get(TEST_HEADER).map(|v| v.as_bytes()),
+            Some(b"secret".as_slice())
+        );
+    }
+
+    #[test]
+    fn apply_does_not_attach_header_to_non_matching_host() {
+        let uri: Uri = "https://evil.com/config".parse().unwrap();
+        let mut headers = HeaderMap::new();
+        scoped(&[SUFFIX]).apply(&uri, &mut headers);
+        assert!(!headers.contains_key(TEST_HEADER));
+    }
+
+    #[test]
+    fn apply_is_noop_when_uri_has_no_host() {
+        let uri: Uri = "/relative/path".parse().unwrap();
+        assert!(uri.host().is_none());
+        let mut headers = HeaderMap::new();
+        scoped(&[SUFFIX]).apply(&uri, &mut headers);
+        assert!(headers.is_empty());
+    }
+
+    #[test]
+    fn apply_does_not_overwrite_existing_header() {
+        let uri: Uri = "https://speed.cloudflare.com/config".parse().unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static(TEST_HEADER),
+            HeaderValue::from_static("explicit"),
+        );
+        scoped(&[SUFFIX]).apply(&uri, &mut headers);
+        assert_eq!(
+            headers.get(TEST_HEADER).map(|v| v.as_bytes()),
+            Some(b"explicit".as_slice())
+        );
+    }
+}

--- a/crates/nq-latency/src/lib.rs
+++ b/crates/nq-latency/src/lib.rs
@@ -7,7 +7,7 @@ use anyhow::Context;
 use http::Request;
 use http_body_util::BodyExt;
 use nq_core::Network;
-use nq_core::{ConnectionType, Time, Timestamp};
+use nq_core::{ConnectionType, ScopedHeaders, Time, Timestamp};
 use nq_stats::TimeSeries;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -17,6 +17,9 @@ use url::Url;
 pub struct LatencyConfig {
     pub url: Url,
     pub runs: usize,
+    /// Headers attached only to requests whose host matches the scope's
+    /// allowlist.
+    pub scoped_headers: Option<ScopedHeaders>,
 }
 
 impl Default for LatencyConfig {
@@ -26,6 +29,7 @@ impl Default for LatencyConfig {
                 .parse()
                 .unwrap(),
             runs: 20,
+            scoped_headers: None,
         }
     }
 }
@@ -94,11 +98,14 @@ impl Latency {
             );
 
             // perform a simple GET to do some amount of work
+            let mut request = Request::get(url.as_str()).body(Default::default())?;
+            if let Some(scoped_headers) = &self.config.scoped_headers {
+                let request_uri = request.uri().clone();
+                scoped_headers.apply(&request_uri, request.headers_mut());
+            }
+
             let response = network
-                .send_request(
-                    connection,
-                    Request::get(url.as_str()).body(Default::default())?,
-                )
+                .send_request(connection, request)
                 .await
                 .context("GET request failed")?;
 

--- a/crates/nq-load-generator/src/lib.rs
+++ b/crates/nq-load-generator/src/lib.rs
@@ -72,13 +72,10 @@ impl LoadGenerator {
             Direction::Up(size) => ThroughputClient::upload(size),
         };
 
-        let mut client = client
+        let client = client
             .new_connection(conn_type)
-            .headers(self.headers.clone());
-
-        if let Some(scoped_headers) = self.scoped_headers.clone() {
-            client = client.scoped_headers(scoped_headers);
-        }
+            .headers(self.headers.clone())
+            .scoped_headers(self.scoped_headers.clone());
 
         let response_fut = client.send(
             match direction {

--- a/crates/nq-load-generator/src/lib.rs
+++ b/crates/nq-load-generator/src/lib.rs
@@ -7,8 +7,8 @@ use anyhow::Context;
 use http::{HeaderMap, HeaderName, HeaderValue};
 use nq_core::client::{Direction, ThroughputClient};
 use nq_core::{
-    BodyEvent, ConnectionType, EstablishedConnection, Network, OneshotResult, Time, Timestamp,
-    oneshot_result,
+    BodyEvent, ConnectionType, EstablishedConnection, Network, OneshotResult, ScopedHeaders, Time,
+    Timestamp, oneshot_result,
 };
 use nq_stats::CounterSeries;
 use rand::seq::SliceRandom;
@@ -21,6 +21,10 @@ use tracing::Instrument;
 #[derive(Debug, Deserialize)]
 pub struct LoadConfig {
     pub headers: HashMap<String, String>,
+    /// Headers attached only to requests whose host matches the scope's
+    /// allowlist.
+    #[serde(skip)]
+    pub scoped_headers: Option<ScopedHeaders>,
     pub download_url: url::Url,
     pub upload_url: url::Url,
     pub upload_size: usize,
@@ -28,6 +32,7 @@ pub struct LoadConfig {
 
 pub struct LoadGenerator {
     headers: HeaderMap<HeaderValue>,
+    scoped_headers: Option<ScopedHeaders>,
     config: LoadConfig,
     loads: Vec<LoadedConnection>,
 }
@@ -45,6 +50,7 @@ impl LoadGenerator {
 
         Ok(Self {
             headers,
+            scoped_headers: config.scoped_headers.clone(),
             config,
             loads: Vec::new(),
         })
@@ -66,18 +72,23 @@ impl LoadGenerator {
             Direction::Up(size) => ThroughputClient::upload(size),
         };
 
-        let response_fut = client
+        let mut client = client
             .new_connection(conn_type)
-            .headers(self.headers.clone())
-            .send(
-                match direction {
-                    Direction::Up(_) => self.config.upload_url.as_str().parse()?,
-                    Direction::Down => self.config.download_url.as_str().parse()?,
-                },
-                network,
-                time,
-                shutdown,
-            )?;
+            .headers(self.headers.clone());
+
+        if let Some(scoped_headers) = self.scoped_headers.clone() {
+            client = client.scoped_headers(scoped_headers);
+        }
+
+        let response_fut = client.send(
+            match direction {
+                Direction::Up(_) => self.config.upload_url.as_str().parse()?,
+                Direction::Down => self.config.download_url.as_str().parse()?,
+            },
+            network,
+            time,
+            shutdown,
+        )?;
 
         tracing::debug!("got loaded connection response future");
 

--- a/crates/nq-packetloss/src/lib.rs
+++ b/crates/nq-packetloss/src/lib.rs
@@ -9,7 +9,7 @@
 
 mod webrtc_data_channel;
 
-use nq_core::{ConnectionType, Network, Time, TokioTime, client::Direction};
+use nq_core::{ConnectionType, Network, ScopedHeaders, Time, TokioTime, client::Direction};
 use nq_load_generator::{LoadConfig, LoadGenerator, LoadedConnection};
 use nq_tokio_network::TokioNetwork;
 use serde::{Deserialize, Serialize};
@@ -38,6 +38,9 @@ pub struct PacketLossConfig {
     pub download_url: Url,
     /// Upload URL to use for for the [`LoadGenerator`]
     pub upload_url: Url,
+    /// Headers attached only to requests whose host matches the scope's
+    /// allowlist.
+    pub scoped_headers: Option<ScopedHeaders>,
 }
 
 impl Default for PacketLossConfig {
@@ -53,6 +56,7 @@ impl Default for PacketLossConfig {
                 .parse()
                 .unwrap(),
             upload_url: "https://h3.speed.cloudflare.com/__up".parse().unwrap(),
+            scoped_headers: None,
         }
     }
 }
@@ -61,6 +65,7 @@ impl PacketLossConfig {
     pub fn load_config(&self) -> LoadConfig {
         LoadConfig {
             headers: HashMap::default(),
+            scoped_headers: self.scoped_headers.clone(),
             download_url: self.download_url.clone(),
             upload_url: self.upload_url.clone(),
             upload_size: 4_000_000_000, // 4 GB
@@ -359,6 +364,7 @@ mod tests {
                 .parse()
                 .unwrap(),
             upload_url: "https://h3.speed.cloudflare.com/__up".parse().unwrap(),
+            scoped_headers: None,
         };
         let packet_loss = PacketLoss::new_with_config(config)?;
         let packet_loss_result = packet_loss
@@ -465,6 +471,7 @@ mod tests {
                 .parse()
                 .unwrap(),
             upload_url: "https://h3.speed.cloudflare.com/__up".parse().unwrap(),
+            scoped_headers: None,
         };
         let packet_loss = PacketLoss::new_with_config(config)?;
 

--- a/crates/nq-rpm/src/lib.rs
+++ b/crates/nq-rpm/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 
 use humansize::{DECIMAL, format_size};
 use nq_core::{
-    ConnectionType, Network, Time, Timestamp,
+    ConnectionType, Network, ScopedHeaders, Time, Timestamp,
     client::{Direction, ThroughputClient, wait_for_finish},
 };
 use nq_load_generator::{LoadConfig, LoadGenerator, LoadedConnection};
@@ -35,12 +35,16 @@ pub struct ResponsivenessConfig {
     pub max_loaded_connections: usize,
     pub conn_type: ConnectionType,
     pub determine_load_only: bool,
+    /// Headers attached only to requests whose host matches the scope's
+    /// allowlist.
+    pub scoped_headers: Option<ScopedHeaders>,
 }
 
 impl ResponsivenessConfig {
     pub fn load_config(&self) -> LoadConfig {
         LoadConfig {
             headers: HashMap::default(),
+            scoped_headers: self.scoped_headers.clone(),
             download_url: self.large_download_url.clone(),
             upload_url: self.upload_url.clone(),
             upload_size: 4_000_000_000, // 4 GB
@@ -66,6 +70,7 @@ impl Default for ResponsivenessConfig {
             max_loaded_connections: 16,
             conn_type: ConnectionType::H2,
             determine_load_only: false,
+            scoped_headers: None,
         }
     }
 }
@@ -443,14 +448,17 @@ impl Responsiveness {
         env: &Env,
         shutdown: CancellationToken,
     ) -> anyhow::Result<()> {
-        let inflight_body_fut = ThroughputClient::download()
-            .new_connection(ConnectionType::H2)
-            .send(
-                self.config.small_download_url.as_str().parse()?,
-                Arc::clone(&env.network),
-                Arc::clone(&env.time),
-                shutdown,
-            )?;
+        let mut client = ThroughputClient::download().new_connection(ConnectionType::H2);
+        if let Some(scoped_headers) = self.config.scoped_headers.clone() {
+            client = client.scoped_headers(scoped_headers);
+        }
+
+        let inflight_body_fut = client.send(
+            self.config.small_download_url.as_str().parse()?,
+            Arc::clone(&env.network),
+            Arc::clone(&env.time),
+            shutdown,
+        )?;
 
         tokio::spawn(report_err(
             event_tx.clone(),
@@ -511,14 +519,17 @@ impl Responsiveness {
             return Ok(false);
         };
 
-        let inflight_body_fut = ThroughputClient::download()
-            .with_connection(connection)
-            .send(
-                self.config.small_download_url.as_str().parse()?,
-                Arc::clone(&env.network),
-                Arc::clone(&env.time),
-                shutdown,
-            )?;
+        let mut client = ThroughputClient::download().with_connection(connection);
+        if let Some(scoped_headers) = self.config.scoped_headers.clone() {
+            client = client.scoped_headers(scoped_headers);
+        }
+
+        let inflight_body_fut = client.send(
+            self.config.small_download_url.as_str().parse()?,
+            Arc::clone(&env.network),
+            Arc::clone(&env.time),
+            shutdown,
+        )?;
 
         tokio::spawn(report_err(
             event_tx.clone(),

--- a/crates/nq-rpm/src/lib.rs
+++ b/crates/nq-rpm/src/lib.rs
@@ -448,10 +448,9 @@ impl Responsiveness {
         env: &Env,
         shutdown: CancellationToken,
     ) -> anyhow::Result<()> {
-        let mut client = ThroughputClient::download().new_connection(ConnectionType::H2);
-        if let Some(scoped_headers) = self.config.scoped_headers.clone() {
-            client = client.scoped_headers(scoped_headers);
-        }
+        let client = ThroughputClient::download()
+            .new_connection(ConnectionType::H2)
+            .scoped_headers(self.config.scoped_headers.clone());
 
         let inflight_body_fut = client.send(
             self.config.small_download_url.as_str().parse()?,
@@ -519,10 +518,9 @@ impl Responsiveness {
             return Ok(false);
         };
 
-        let mut client = ThroughputClient::download().with_connection(connection);
-        if let Some(scoped_headers) = self.config.scoped_headers.clone() {
-            client = client.scoped_headers(scoped_headers);
-        }
+        let client = ThroughputClient::download()
+            .with_connection(connection)
+            .scoped_headers(self.config.scoped_headers.clone());
 
         let inflight_body_fut = client.send(
             self.config.small_download_url.as_str().parse()?,


### PR DESCRIPTION
Add optional Cloudflare Access support via the `MACH_CF_ACCESS_TOKEN` env var. 
When set, mach attaches a redacted `cf-access-token header` to test requests, scoped to speed.cloudflare.com with strict domain-label matching so it never leaks to unrelated origins. 

Closes #43 